### PR TITLE
Remove workaround to improve cursor selection performance

### DIFF
--- a/src/mplcursors/_mplcursors.py
+++ b/src/mplcursors/_mplcursors.py
@@ -7,6 +7,7 @@ import sys
 import weakref
 from weakref import WeakKeyDictionary, WeakSet
 
+import matplotlib as mpl
 from matplotlib.axes import Axes
 from matplotlib.container import Container
 from matplotlib.figure import Figure
@@ -95,11 +96,15 @@ def _iter_axes_subartists(ax):
 
 def _is_alive(artist):
     """Check whether *artist* is still present on its parent axes."""
-    return bool(artist
-                and artist.axes
-                and (artist.container in artist.axes.containers
-                     if isinstance(artist, _pick_info.ContainerArtist) else
-                     artist in _iter_axes_subartists(artist.axes)))
+    return bool(
+        artist
+        and artist.axes
+        # `cla()` clears `.axes` since matplotlib/matplotlib#24627 (3.7);
+        # iterating over subartists can be very slow.
+        and (getattr(mpl, "__version_info__", ()) >= (3, 7)
+             or (artist.container in artist.axes.containers
+                 if isinstance(artist, _pick_info.ContainerArtist) else
+                 artist in _iter_axes_subartists(artist.axes))))
 
 
 def _reassigned_axes_event(event, ax):
@@ -288,8 +293,6 @@ class Cursor:
     @property
     def artists(self):
         """The tuple of selectable artists."""
-        # Work around matplotlib/matplotlib#6982: `cla()` does not clear
-        # `.axes`.
         return tuple(filter(_is_alive, (ref() for ref in self._artists)))
 
     @property


### PR DESCRIPTION
This change reduces the time it takes from selection until the annotation is visible to 10%. In my use case with around 4500 lines it previously took 47s. After this change it only takes around 5s. The workaround mentioned in the code is for a defect which was fixed in 2022.