### PR TITLE
Fix AttributeError: 'numpy.int64' object has no attribute 'rstrip'

### DIFF
--- a/src/mplcursors/_pick_info.py
+++ b/src/mplcursors/_pick_info.py
@@ -506,8 +506,8 @@ def _format_coord_unspaced(ax, pos):
         x, y = pos
         # In mpl<3.3 (before #16776) format_x/ydata included trailing
         # spaces, hence the rstrip() calls.
-        return (f"x={ax.format_xdata(x).rstrip()}\n"
-                f"y={ax.format_ydata(y).rstrip()}")
+        return (f"x={str(ax.format_xdata(x)).rstrip()}\n"
+                f"y={str(ax.format_ydata(y)).rstrip()}")
 
 
 @functools.singledispatch


### PR DESCRIPTION
This change resolves AttributeError when working with numpy and matplotlib.pyplot.